### PR TITLE
画面遷移(トップページとログイン画面)

### DIFF
--- a/src/components/atoms/PrimaryBtn.tsx
+++ b/src/components/atoms/PrimaryBtn.tsx
@@ -1,12 +1,13 @@
 import { ReactNode } from 'react'
 
 type PropsType = {
+    onClick:()=> void;
     children:ReactNode;
 }
 
-export const PrimaryBtn = ({ children }: PropsType) => {
+export const PrimaryBtn = ({ onClick,children }: PropsType) => {
     return (
-        <button className="bg-lime-800 text-white p-4 rounded-lg text-lg">
+        <button className="bg-lime-800 text-white p-4 rounded-lg text-lg" onClick={onClick}>
             { children }
         </button>
     )

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -20,7 +20,7 @@ export const LoginPage = () => {
                         placeholder="パスワード"
                     />
                 </div>
-                <PrimaryBtn>ログイン</PrimaryBtn>
+                <PrimaryBtn onClick={()=> null}>ログイン</PrimaryBtn>
             </form>
         </div>
     )

--- a/src/components/pages/TopPage.tsx
+++ b/src/components/pages/TopPage.tsx
@@ -1,12 +1,14 @@
+import { useNavigate } from 'react-router-dom'
 import { PrimaryBtn } from '../atoms/PrimaryBtn'
 
 export const TopPage = () => {
+    const navigate = useNavigate()
     return (
         <div className="text-center">
             <h1 className="text-7xl logo">スケジュール管理</h1>
             <p className="pt-[10vh] text-5xl">お互いのスケジュールを管理する</p>
             <div className="pt-[20vh]">
-                <PrimaryBtn>ログイン</PrimaryBtn>
+                <PrimaryBtn onClick={()=> navigate("/login")}>ログイン</PrimaryBtn>
             </div>
         </div>
     )

--- a/src/components/templates/NotLoginLayout.tsx
+++ b/src/components/templates/NotLoginLayout.tsx
@@ -1,15 +1,19 @@
-import { Outlet } from 'react-router-dom'
+import { Link,Outlet } from 'react-router-dom'
 
 export const NotLoginLayout = () => {
     return (
         <div className="relative">
             <header className="bg-white leading-[50px] fixed top-0 right-0 left-0">
                 <div className="container mx-auto flex justify-between">
-                    <p className="logo">スケジュール管理App</p>
+                    <p className="logo">
+                        <Link to="/">スケジュール管理App</Link>
+                    </p>
                     <nav>
                         <ul className="flex gap-5 text-lime-800">
                             <li>利用説明</li>
-                            <li>ログイン</li>
+                            <li>
+                                <Link to="/login">ログイン</Link>
+                            </li>
                         </ul>
                     </nav>
                 </div>


### PR DESCRIPTION
- スケジュール管理Appはトップページに遷移

<img width="1431" alt="スクリーンショット 2025-06-01 0 05 53" src="https://github.com/user-attachments/assets/4c850202-892a-416a-9170-13929caa9f5c" />

- ログインを押すとログイン画面に遷移
<img width="1438" alt="スクリーンショット 2025-06-01 0 06 51" src="https://github.com/user-attachments/assets/4c05223d-8e34-40ff-a007-efbbb3b828f2" />

- ログインボタンはnullでセットする