### PR TITLE
カレンダーページに日付のレイアウト調整

### DIFF
--- a/src/components/pages/CalendarPage.tsx
+++ b/src/components/pages/CalendarPage.tsx
@@ -1,10 +1,17 @@
-import { eachWeekOfInterval,eachDayOfInterval,getDate,getMonth,startOfMonth,endOfWeek,endOfMonth } from "date-fns";
+import { eachWeekOfInterval,eachDayOfInterval,getDate,getMonth,startOfMonth,endOfWeek,endOfMonth,isToday,isSameMonth } from "date-fns";
 import { DAYS_LIST } from "../../constants/calendar";
 import { useEffect,useState } from "react";
 
 export const CalendarPage = () => {
   const today = new Date()
   const [dateList,setDateList] = useState<Date[][]>([]);
+
+  const dateColor = (targetDate: Date, currentDate: Date): string => {
+    if (isToday(targetDate)) return "bg-lime-800 text-white rounded-full";
+    return isSameMonth(targetDate, currentDate)
+      ? "text-black"
+      : "text-gray-300";
+  };
 
   useEffect(() => {
     const monthOfSundayList = eachWeekOfInterval({
@@ -42,7 +49,12 @@ export const CalendarPage = () => {
                       key={`day-${getDate(item)}`}
                       className="bg-white h-[10vh] border-lime-800 border-2 border-solid"
                     >
-                      <span className="inline-block w-[20%] leading-[20%] text-center">
+                      <span
+                        className={`inline-block w-[20px] leading-[20px] text-center ${dateColor(
+                          item,
+                          today
+                        )}`}
+                      >
                         {getDate(item)}
                       </span>
                     </td>


### PR DESCRIPTION
- ***今日の場合はlimeで丸く背景色をつける***

- ***今月でない日付（先月の月終わりの日付、来月の月初の日付）は灰色***

- ***上記以外は黒***

<img width="1438" alt="スクリーンショット 2025-06-11 23 53 24" src="https://github.com/user-attachments/assets/5292ae98-c961-4d62-b663-58709cf3cee6" />
